### PR TITLE
fix: 改用通用 Agent Skills 安装入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,73 +6,35 @@
 
 Source: [github.com/leftzzzz/agents-spec-skill](https://github.com/leftzzzz/agents-spec-skill)
 
-The repository maintains one canonical Skill: `skills/agents-spec/SKILL.md`. Codex, Claude Code, Cursor, GitHub Copilot, OpenCode, and other compatible agents load the same Skill. Platform manifests only provide discovery and installation; they do not duplicate the Skill body.
+The repository maintains one canonical Skill: `skills/agents-spec/SKILL.md`. Every compatible agent loads the same Skill. Platform manifests only provide discovery and installation; they do not duplicate the Skill body.
 
 ## Language support
 
 The Skill works with Chinese prompts and Chinese-language repositories. Its internal instructions remain in English for consistent cross-agent behavior, but you can describe tasks in Chinese or English.
 
-## One-command installation
+## Installing
 
-The commands below require Node.js 22.20 or newer, which is the runtime requirement of the current [`skills` CLI](https://github.com/vercel-labs/skills).
-
-Each command installs the Skill globally so it is available in all projects for that agent. Choose your agent and run the corresponding command.
-
-### Cursor
+The [`npx skills add`](https://github.com/vercel-labs/skills) CLI scans the `skills/` directory in this repository. Every agent supported by the CLI uses the same installation command, so this README does not maintain a platform-specific command list.
 
 ```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent cursor --global --yes
+npx skills add https://github.com/leftzzzz/agents-spec-skill
 ```
 
-### Claude Code
+This repository currently contains one Skill. You can also select it explicitly by its **install name** (the `name:` field in the `SKILL.md` frontmatter, not the directory name):
 
 ```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent claude-code --global --yes
+npx skills add https://github.com/leftzzzz/agents-spec-skill --skill "agents-spec"
 ```
 
-### Codex
+The installer handles agent selection and installation scope, while its own supported-agent registry stays current as new agents are added.
+
+To install from a local checkout instead:
 
 ```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent codex --global --yes
+npx skills add ./agents-spec-skill
 ```
 
-### GitHub Copilot
-
-```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent github-copilot --global --yes
-```
-
-### OpenCode
-
-```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent opencode --global --yes
-```
-
-### Choose another agent interactively
-
-If you omit `--agent`, the installer detects supported agents and prompts you to choose the target agent and installation scope:
-
-```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec
-```
-
-In the commands above, `--global` means user-level installation and `--yes` skips confirmation prompts. For a project-only installation, enter the project root and remove `--global`.
-
-You can also try a local checkout before the GitHub repository is published:
-
-```bash
-npx --yes skills add ./agents-spec-skill --skill agents-spec
-```
-
-For manual installation, copy the complete `skills/agents-spec/` directory to the corresponding location:
-
-| Agent | Project directory | Global directory |
-| --- | --- | --- |
-| Claude Code | `.claude/skills/` | `~/.claude/skills/` |
-| Codex | `.agents/skills/` | `~/.codex/skills/` |
-| Cursor | `.agents/skills/` | `~/.cursor/skills/` |
-| GitHub Copilot | `.agents/skills/` | `~/.copilot/skills/` |
-| OpenCode | `.agents/skills/` | `~/.config/opencode/skills/` |
+For manual installation, copy the complete `skills/agents-spec/` directory to the Skill directory documented by your agent.
 
 ## Usage
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 源代码：[github.com/leftzzzz/agents-spec-skill](https://github.com/leftzzzz/agents-spec-skill)
 
-仓库只维护一份权威 Skill：`skills/agents-spec/SKILL.md`。Codex、Claude Code、Cursor、GitHub Copilot、OpenCode 及其他兼容 Agent 均加载这份 Skill；各平台清单只负责发现和安装，不复制 Skill 内容。
+仓库只维护一份权威 Skill：`skills/agents-spec/SKILL.md`。所有兼容 Agent 均加载这份 Skill；各平台清单只负责发现和安装，不复制 Skill 内容。
 
 ## 中文支持
 
@@ -14,65 +14,27 @@ Skill 支持中文提示词和中文仓库。Skill 的内部指令使用英文�
 
 ## 一键安装
 
-安装命令依赖 Node.js 22.20 或更高版本，这是当前 [`skills` CLI](https://github.com/vercel-labs/skills) 的运行要求。
-
-下面的命令均为全局安装，执行一次后可在该 Agent 的所有项目中使用。请选择你正在使用的平台，复制对应的一条命令执行即可。
-
-### Cursor
+[`npx skills add`](https://github.com/vercel-labs/skills) CLI 会扫描本仓库的 `skills/` 目录。该 CLI 支持的所有 Agent 都使用同一条安装命令，因此 README 不再维护各平台的专用命令清单。
 
 ```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent cursor --global --yes
+npx skills add https://github.com/leftzzzz/agents-spec-skill
 ```
 
-### Claude Code
+本仓库目前只有一个 Skill。你也可以通过它的**安装名**明确选择；安装名来自 `SKILL.md` frontmatter 中的 `name:` 字段，而不是目录名：
 
 ```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent claude-code --global --yes
+npx skills add https://github.com/leftzzzz/agents-spec-skill --skill "agents-spec"
 ```
 
-### Codex
+安装器负责选择 Agent 和安装范围；未来增加新 Agent 时，由安装器自己的支持清单统一更新。
+
+也可以从本地检出的仓库安装：
 
 ```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent codex --global --yes
+npx skills add ./agents-spec-skill
 ```
 
-### GitHub Copilot
-
-```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent github-copilot --global --yes
-```
-
-### OpenCode
-
-```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec --agent opencode --global --yes
-```
-
-### 交互式选择其他 Agent
-
-不指定 `--agent` 时，安装器会检测已支持的 Agent，并让你选择安装目标与安装范围：
-
-```bash
-npx --yes skills add leftzzzz/agents-spec-skill --skill agents-spec
-```
-
-以上单平台命令中的 `--global` 表示全局安装，`--yes` 表示无需交互确认。如需仅在当前项目安装，请先进入项目根目录，再执行对应命令并删除 `--global` 参数。
-
-也可以从本地检出的仓库试装：
-
-```bash
-npx --yes skills add ./agents-spec-skill --skill agents-spec
-```
-
-手动安装时，将完整的 `skills/agents-spec/` 目录复制到对应位置：
-
-| Agent | 项目级目录 | 全局目录 |
-| --- | --- | --- |
-| Claude Code | `.claude/skills/` | `~/.claude/skills/` |
-| Codex | `.agents/skills/` | `~/.codex/skills/` |
-| Cursor | `.agents/skills/` | `~/.cursor/skills/` |
-| GitHub Copilot | `.agents/skills/` | `~/.copilot/skills/` |
-| OpenCode | `.agents/skills/` | `~/.config/opencode/skills/` |
+如需手动安装，请将完整的 `skills/agents-spec/` 目录复制到目标 Agent 文档指定的 Skill 目录。
 
 ## 使用
 

--- a/tests/test_skill_package.py
+++ b/tests/test_skill_package.py
@@ -53,7 +53,9 @@ class SkillPackageTests(unittest.TestCase):
 
         self.assertIn(f"github.com/leftzzzz/{REPOSITORY_NAME}", readme)
         self.assertIn(f"${SKILL_NAME}", readme)
-        self.assertIn(f"npx --yes skills add leftzzzz/{REPOSITORY_NAME}", readme)
+        self.assertIn(
+            f"npx skills add https://github.com/leftzzzz/{REPOSITORY_NAME}", readme
+        )
         self.assertIn("[English](README.md) | [简体中文](README.zh-CN.md)", readme)
         self.assertIn("[English](README.md) | **简体中文**", readme_zh)
         self.assertIn("## Language support", readme)
@@ -65,31 +67,22 @@ class SkillPackageTests(unittest.TestCase):
             license_text, (SKILL_ROOT / "LICENSE.txt").read_text(encoding="utf-8")
         )
 
-    def test_readme_has_one_command_global_install_for_each_primary_agent(
+    def test_readmes_use_one_generic_install_command_for_supported_agents(
         self,
     ) -> None:
         readmes = {
             "English": (ROOT / "README.md").read_text(encoding="utf-8"),
             "Chinese": (ROOT / "README.zh-CN.md").read_text(encoding="utf-8"),
         }
-        command_prefix = (
-            f"npx --yes skills add leftzzzz/{REPOSITORY_NAME} "
-            f"--skill {SKILL_NAME} --agent"
-        )
+        command = f"npx skills add https://github.com/leftzzzz/{REPOSITORY_NAME}"
+        named_skill_command = f'{command} --skill "{SKILL_NAME}"'
 
         for language, readme in readmes.items():
-            for agent in [
-                "cursor",
-                "claude-code",
-                "codex",
-                "github-copilot",
-                "opencode",
-            ]:
-                with self.subTest(language=language, agent=agent):
-                    self.assertIn(
-                        f"{command_prefix} {agent} --global --yes",
-                        readme,
-                    )
+            with self.subTest(language=language):
+                self.assertIn(command, readme)
+                self.assertIn(named_skill_command, readme)
+                self.assertIn("`skills/`", readme)
+                self.assertNotRegex(readme, r"npx skills add[^\n]*--agent(?:\s|=)")
 
     def test_native_manifests_are_thin_and_share_one_skill_directory(self) -> None:
         manifest_paths = [


### PR DESCRIPTION
## 变更

- 参照 Taste Skill 的安装模式，统一使用 `npx skills add <repo>` 扫描 `skills/` 目录
- 删除 Cursor、Claude Code、Codex、GitHub Copilot、OpenCode 的固定命令和手动路径表
- 保留通过 `SKILL.md` frontmatter `name` 安装单个 Skill 的方式
- 同步更新英文与中文 README，并增加防止固定 Agent 安装命令回归的测试

## 原因与影响

原安装说明把 Agent 支持范围固化在 README 中，新增 Agent 时容易过期。改为由 Agent Skills CLI 维护支持矩阵后，当前和未来受支持的 Agent 均使用同一入口。

## 验证

- `python3.11 -m unittest discover -s tests -v`（29 tests）
- `ruff check skills tests`
- `ruff format --check skills tests`
- `skills-ref validate skills/agents-spec`
- `npx --yes skills@1.5.23 add <local-repo> --list`
- 在临时 Git 项目中运行 `npx --yes skills@1.5.23 add <local-repo> --all`（CLI 检测并安装到当前支持的 77 个 Agent）
- `npx --yes @anthropic-ai/claude-code@2.1.229 plugin validate .`